### PR TITLE
Fix deprecation

### DIFF
--- a/lib/stale.js
+++ b/lib/stale.js
@@ -122,16 +122,16 @@ module.exports = class Stale {
     const perform = this.getConfigValue(type, 'perform')
     const staleLabel = this.getConfigValue(type, 'staleLabel')
     const markComment = this.getConfigValue(type, 'markComment')
-    const number = issue.number
+    const issue_number = issue.number
 
     if (perform) {
-      this.logger.info('%s/%s#%d is being marked', owner, repo, number)
+      this.logger.info('%s/%s#%d is being marked', owner, repo, issue_number)
       if (markComment) {
-        await this.github.issues.createComment({ owner, repo, number, body: markComment })
+        await this.github.issues.createComment({ owner, repo, issue_number, body: markComment })
       }
       return this.github.issues.addLabels({ owner, repo, number, labels: [staleLabel] })
     } else {
-      this.logger.info('%s/%s#%d would have been marked (dry-run)', owner, repo, number)
+      this.logger.info('%s/%s#%d would have been marked (dry-run)', owner, repo, issue_number)
     }
   }
 
@@ -144,16 +144,16 @@ module.exports = class Stale {
     const { owner, repo } = this.config
     const perform = this.getConfigValue(type, 'perform')
     const closeComment = this.getConfigValue(type, 'closeComment')
-    const number = issue.number
+    const issue_number = issue.number
 
     if (perform) {
-      this.logger.info('%s/%s#%d is being closed', owner, repo, number)
+      this.logger.info('%s/%s#%d is being closed', owner, repo, issue_number)
       if (closeComment) {
-        await this.github.issues.createComment({ owner, repo, number, body: closeComment })
+        await this.github.issues.createComment({ owner, repo, issue_number, body: closeComment })
       }
       return this.github.issues.update({ owner, repo, number, state: 'closed' })
     } else {
-      this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, number)
+      this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, issue_number)
     }
   }
 

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -122,16 +122,16 @@ module.exports = class Stale {
     const perform = this.getConfigValue(type, 'perform')
     const staleLabel = this.getConfigValue(type, 'staleLabel')
     const markComment = this.getConfigValue(type, 'markComment')
-    const issue_number = issue.number
+    const number = issue.number
 
     if (perform) {
-      this.logger.info('%s/%s#%d is being marked', owner, repo, issue_number)
+      this.logger.info('%s/%s#%d is being marked', owner, repo, number)
       if (markComment) {
-        await this.github.issues.createComment({ owner, repo, issue_number, body: markComment })
+        await this.github.issues.createComment({ owner, repo, issue_number: number, body: markComment })
       }
-      return this.github.issues.addLabels({ owner, repo, number, labels: [staleLabel] })
+      return this.github.issues.addLabels({ owner, repo, issue_number: number, labels: [staleLabel] })
     } else {
-      this.logger.info('%s/%s#%d would have been marked (dry-run)', owner, repo, issue_number)
+      this.logger.info('%s/%s#%d would have been marked (dry-run)', owner, repo, number)
     }
   }
 
@@ -144,16 +144,16 @@ module.exports = class Stale {
     const { owner, repo } = this.config
     const perform = this.getConfigValue(type, 'perform')
     const closeComment = this.getConfigValue(type, 'closeComment')
-    const issue_number = issue.number
+    const number = issue.number
 
     if (perform) {
-      this.logger.info('%s/%s#%d is being closed', owner, repo, issue_number)
+      this.logger.info('%s/%s#%d is being closed', owner, repo, number)
       if (closeComment) {
-        await this.github.issues.createComment({ owner, repo, issue_number, body: closeComment })
+        await this.github.issues.createComment({ owner, repo, issue_number: number, body: closeComment })
       }
-      return this.github.issues.update({ owner, repo, number, state: 'closed' })
+      return this.github.issues.update({ owner, repo, issue_number: number, state: 'closed' })
     } else {
-      this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, issue_number)
+      this.logger.info('%s/%s#%d would have been closed (dry-run)', owner, repo, number)
     }
   }
 
@@ -169,7 +169,7 @@ module.exports = class Stale {
 
     if (perform) {
       this.logger.info('%s/%s#%d is being reopened', owner, repo, number)
-      return this.github.issues.edit({ owner, repo, number, state: 'open' })
+      return this.github.issues.update({ owner, repo, issue_number: number, state: 'open' })
     } else {
       this.logger.info('%s/%s#%d would have been reopened (dry-run)', owner, repo, number)
     }
@@ -187,14 +187,14 @@ module.exports = class Stale {
       this.logger.info('%s/%s#%d is being unmarked', owner, repo, number)
 
       if (unmarkComment) {
-        await this.github.issues.createComment({ owner, repo, number, body: unmarkComment })
+        await this.github.issues.createComment({ owner, repo, issue_number: number, body: unmarkComment })
       }
 
       if (reopenIssue) {
         this.open(type, issue)
       }
 
-      return this.github.issues.removeLabel({ owner, repo, number, name: staleLabel }).catch((err) => {
+      return this.github.issues.removeLabel({ owner, repo, issue_number: number, name: staleLabel }).catch((err) => {
         // ignore if it's a 404 because then the label was already removed
         if (err.code !== 404) {
           throw err


### PR DESCRIPTION
```
stalebot_1  | { Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
stalebot_1  |     at Object.keys.forEach.key (/app/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:71:26)
stalebot_1  |     at Array.forEach (<anonymous>)
stalebot_1  |     at Object.patchedMethod [as createComment] (/app/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:67:26)
stalebot_1  |     at Stale.markIssue (/app/lib/stale.js:130:34)
stalebot_1  |     at Promise.all.staleItems.filter.map.issue (/app/lib/stale.js:45:19)
stalebot_1  |     at Array.map (<anonymous>)
stalebot_1  |     at Stale.mark (/app/lib/stale.js:44:65) name: 'Deprecation' }

```